### PR TITLE
Add news list feature with BLoC architecture

### DIFF
--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -10,7 +10,7 @@ class Routes
   static Map<String, WidgetBuilder>  routes = {
     SplashScreen.id:(context)=>const SplashScreen(),
     CategoryScreen.id:(context)=>const CategoryScreen(),
-    HomeCategoryScreen.id:(context)=>const HomeCategoryScreen(),
+    HomeCategoryScreen.id:(context)=> HomeCategoryScreen(),
     DetailsScreen.id:(context)=>const DetailsScreen(),
     SearchScreen.id:(context)=>const SearchScreen(),
 

--- a/lib/features/one_category_feature/data/models/NewsListModel.dart
+++ b/lib/features/one_category_feature/data/models/NewsListModel.dart
@@ -1,0 +1,81 @@
+import '../../../category_features/data/models/source_model.dart';
+
+class NewsListModel {
+  NewsListModel({
+      this.status, 
+      this.totalResults, 
+      this.articles,});
+
+  NewsListModel.fromJson(dynamic json) {
+    status = json['status'];
+    totalResults = json['totalResults'];
+    if (json['articles'] != null) {
+      articles = [];
+      json['articles'].forEach((v) {
+        articles?.add(Articles.fromJson(v));
+      });
+    }
+  }
+  String? status;
+  num? totalResults;
+  List<Articles>? articles;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['status'] = status;
+    map['totalResults'] = totalResults;
+    if (articles != null) {
+      map['articles'] = articles?.map((v) => v.toJson()).toList();
+    }
+    return map;
+  }
+
+}
+
+class Articles {
+  Articles({
+      this.source, 
+      this.author, 
+      this.title, 
+      this.description, 
+      this.url, 
+      this.urlToImage, 
+      this.publishedAt, 
+      this.content,});
+
+  Articles.fromJson(dynamic json) {
+    source = json['source'] != null ? Sources.fromJson(json['source']) : null;
+    author = json['author'];
+    title = json['title'];
+    description = json['description'];
+    url = json['url'];
+    urlToImage = json['urlToImage'];
+    publishedAt = json['publishedAt'];
+    content = json['content'];
+  }
+  Sources? source;
+  String? author;
+  String? title;
+  String? description;
+  String? url;
+  String? urlToImage;
+  String? publishedAt;
+  String? content;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (source != null) {
+      map['source'] = source?.toJson();
+    }
+    map['author'] = author;
+    map['title'] = title;
+    map['description'] = description;
+    map['url'] = url;
+    map['urlToImage'] = urlToImage;
+    map['publishedAt'] = publishedAt;
+    map['content'] = content;
+    return map;
+  }
+
+}
+

--- a/lib/features/one_category_feature/data/repositories/get_news_list_repo.dart
+++ b/lib/features/one_category_feature/data/repositories/get_news_list_repo.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import 'package:news_app_route1/core/networking/failure.dart';
+import 'package:news_app_route1/features/one_category_feature/data/models/NewsListModel.dart';
+
+abstract class GetNewsListRepository{
+ Future<Either<Failure,List<Articles>>> getNewsList({required String sourceId});
+}

--- a/lib/features/one_category_feature/data/repositories/get_news_list_repo_impliment.dart
+++ b/lib/features/one_category_feature/data/repositories/get_news_list_repo_impliment.dart
@@ -1,0 +1,39 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:news_app_route1/core/networking/dio_helper.dart';
+
+import 'package:news_app_route1/core/networking/failure.dart';
+
+import 'package:news_app_route1/features/one_category_feature/data/models/NewsListModel.dart';
+
+import 'get_news_list_repo.dart';
+
+class GetNewsListRepositoryImpliment implements GetNewsListRepository
+{
+  @override
+  Future<Either<Failure, List<Articles>>> getNewsList({required String sourceId}) async {
+  try {
+    Response response = await DioHelper.getData(
+        url: 'everything?sources=$sourceId&apiKey=d9b26400797f4a56be2cbe5547d6ff12');
+    Map<String, dynamic> map = response.data;
+    List<Articles> articaledList = [];
+    for (var art in map['articles']) {
+      articaledList.add(Articles.fromJson(art));
+    }
+    print(articaledList);
+    return Right(articaledList);
+  }catch(e)
+    {
+      if(e is DioException)
+        {
+          return Left(Failure.fromDioError(e));
+        }
+      else
+        {
+          return left(Failure(message: e.toString()));
+        }
+    }
+    
+  }
+
+}

--- a/lib/features/one_category_feature/presentation/manager/news_list_cubit.dart
+++ b/lib/features/one_category_feature/presentation/manager/news_list_cubit.dart
@@ -1,0 +1,28 @@
+import 'package:bloc/bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:news_app_route1/features/one_category_feature/data/models/NewsListModel.dart';
+import 'package:news_app_route1/features/one_category_feature/data/repositories/get_news_list_repo.dart';
+
+part 'news_list_state.dart';
+
+class NewsListCubit extends Cubit<NewsListState> {
+  NewsListCubit(this.getNewsListRepo) : super(NewsListInitial());
+  final GetNewsListRepository getNewsListRepo;
+  int selected=0;
+  void selectCategory(int index){
+    selected=index;
+    emit(NewsListCategorySelected(selected: selected));
+  }
+
+  Future<void> fetchNewsList({required String sourceId}) async {
+    var res=await getNewsListRepo.getNewsList(sourceId: sourceId);
+    res.fold((e){
+      print(e.toString());
+      emit(NewsListError(errorMessage: e.message));
+    }, (artical){
+      emit(
+        NewsListSuccessData(abstract: artical)
+      );
+    });
+}
+}

--- a/lib/features/one_category_feature/presentation/manager/news_list_state.dart
+++ b/lib/features/one_category_feature/presentation/manager/news_list_state.dart
@@ -1,0 +1,28 @@
+part of 'news_list_cubit.dart';
+
+@immutable
+sealed class NewsListState {}
+
+final class NewsListInitial extends NewsListState {}
+final class NewsListCategorySelected extends NewsListState {
+  final int selected;
+
+  NewsListCategorySelected({required this.selected});
+
+}
+
+
+final class NewsListLoading extends NewsListState {}
+
+final class NewsListError extends NewsListState {
+  final String errorMessage;
+
+  NewsListError({required this.errorMessage});
+}
+
+final class NewsListSuccessData extends NewsListState {
+  final List<Articles>abstract ;
+
+  NewsListSuccessData({required this.abstract});
+
+}

--- a/lib/features/one_category_feature/presentation/pages/home_category_screen.dart
+++ b/lib/features/one_category_feature/presentation/pages/home_category_screen.dart
@@ -1,59 +1,91 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:news_app_route1/core/utile/my_assets.dart';
 import 'package:news_app_route1/features/category_features/data/models/nav_model.dart';
+import 'package:news_app_route1/features/one_category_feature/data/repositories/get_news_list_repo_impliment.dart';
+import 'package:news_app_route1/features/one_category_feature/presentation/manager/news_list_cubit.dart';
+import 'package:news_app_route1/features/search_feature/presentation/pages/search_screen.dart';
 import '../../../../core/themes/my_colors.dart';
 import '../../../../core/themes/my_styles.dart';
 import '../widgets/list_view_of_category_home_screen.dart';
 import '../widgets/tap_bar_section.dart';
 
 class HomeCategoryScreen extends StatelessWidget {
-  static const String id='HomeCategoryScreen';
-  const HomeCategoryScreen({super.key});
+  static const String id = 'HomeCategoryScreen';
+  HomeCategoryScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-   NavigationModel data= ModalRoute.of(context)?.settings.arguments as NavigationModel;
-    return Container(
-      color: MyColors.whiteColor,
+    NavigationModel data =
+        ModalRoute.of(context)?.settings.arguments as NavigationModel;
+    return BlocProvider(
+      create: (context) => NewsListCubit(GetNewsListRepositoryImpliment()),
       child: Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(image: AssetImage(MyAssets.scaffoldBackground))
-        ),
-        child: Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            backgroundColor: MyColors.green,
-            title: Text("${data.title}",style: MyStyles.font22WhiteWeight400Exo,),
-            centerTitle: true,
-            shape: const RoundedRectangleBorder(
-                borderRadius: BorderRadiusDirectional.only(bottomStart:Radius.circular(50) ,bottomEnd:Radius.circular(50) )
-            ),
-            leading: Padding(
-              padding: const EdgeInsetsDirectional.only(start: 29),
-              child:IconButton(onPressed: () {  }, icon: const Icon(Icons.menu,color: MyColors.whiteColor,)
+        color: MyColors.whiteColor,
+        child: Container(
+          decoration: const BoxDecoration(
+              image: DecorationImage(
+                  image: AssetImage(MyAssets.scaffoldBackground))),
+          child: Scaffold(
+            backgroundColor: Colors.transparent,
+            appBar:
+            AppBar(
+              backgroundColor: MyColors.green,
+              title: Text(
+                "${data.title}",
+                style: MyStyles.font22WhiteWeight400Exo,
               ),
+              centerTitle: true,
+              shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadiusDirectional.only(
+                      bottomStart: Radius.circular(50),
+                      bottomEnd: Radius.circular(50))),
+              leading: Padding(
+                padding: const EdgeInsetsDirectional.only(start: 29),
+                child: IconButton(
+                    onPressed: () {},
+                    icon: const Icon(
+                      Icons.menu,
+                      color: MyColors.whiteColor,
+                    )),
+              ),
+              actions: [
+                IconButton(
+                    onPressed: () {
+                      Navigator.pushNamed(context, SearchScreen.id);
+                    },
+                    icon: const Icon(
+                      FontAwesomeIcons.magnifyingGlass,
+                      color: MyColors.whiteColor,
+                    )),
+                SizedBox(
+                  width: 29.w,
+                ),
+              ],
             ),
-            actions: [
-
-              IconButton(onPressed: (){}, icon: const Icon(FontAwesomeIcons.magnifyingGlass,color: MyColors.whiteColor,)),
-              SizedBox(width: 29.w,),
-            ],
+            body: BlocBuilder<NewsListCubit, NewsListState>(
+              builder: (context, state) {
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 15.h,
+                    ),
+                    TapBarSection(
+                      data: data,
+                    ),
+                    ListViewOfCategoryHomeScreen(
+                      sourceId:
+                          "${data.source![BlocProvider.of<NewsListCubit>(context).selected].id}",
+                    )
+                  ],
+                );
+              },
+            ),
           ),
-          body: Column(
-            children: [
-              SizedBox(height: 15.h,),
-              TapBarSection(data: data,),
-              const ListViewOfCategoryHomeScreen()
-            ],
-          ),
-
         ),
       ),
     );
   }
 }
-
-
-

--- a/lib/features/one_category_feature/presentation/widgets/list_view_of_category_home_screen.dart
+++ b/lib/features/one_category_feature/presentation/widgets/list_view_of_category_home_screen.dart
@@ -1,47 +1,112 @@
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:news_app_route1/core/themes/my_colors.dart';
+import 'package:news_app_route1/features/one_category_feature/data/repositories/get_news_list_repo_impliment.dart';
+import 'package:news_app_route1/features/one_category_feature/presentation/manager/news_list_cubit.dart';
 
 import '../../../../core/themes/my_styles.dart';
-import '../../../../core/utile/my_assets.dart';
 
 class ListViewOfCategoryHomeScreen extends StatelessWidget {
   const ListViewOfCategoryHomeScreen({
-    super.key,
+    super.key, required this.sourceId,
   });
-
+  final String sourceId;
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Padding(
-        padding: EdgeInsetsDirectional.only(top: 30.h),
-        child: ListView.separated(
-          physics: BouncingScrollPhysics(),
-          itemCount: 10,
-          itemBuilder: (context, index) =>
-              Column(
-                children: [
-                  Image(image: AssetImage(MyAssets.test)),
-                  Padding(
-                    padding:  EdgeInsetsDirectional.only(start: 30.w),
-                    child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Text('BBC news *',style: MyStyles.font10GreyWeight400Poppins,)),
+    return BlocBuilder<NewsListCubit,NewsListState>(
+      bloc: NewsListCubit(GetNewsListRepositoryImpliment())..fetchNewsList(sourceId: sourceId),
+    builder: (context, state) {
+        if(state is NewsListSuccessData) {
+          return Expanded(
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(top: 30.h),
+              child: ListView.separated(
+                physics: const BouncingScrollPhysics(),
+                itemCount: state.abstract.length,
+                itemBuilder: (context, index) =>
+                    Column(
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(10.w),
+                          child:CachedNetworkImage(
+                            height: 232.h,
+                            width: 360.w,
+                            fit: BoxFit.cover,
+                            imageUrl:"${state.abstract[index].urlToImage}",
+                            progressIndicatorBuilder: (context, url, downloadProgress) =>
+                                Center(child: CircularProgressIndicator(
+                                    color: MyColors.green,
+                                    value: downloadProgress.progress)),
+                            errorWidget: (context, url, error) => const Icon(Icons.error),
+                          ),
+                        ),
+                        Padding(
+                          padding: EdgeInsetsDirectional.only(start: 30.w),
+                          child: Align(
+                              alignment: Alignment.topLeft,
+                              child: Text('${state.abstract[index].source?.name??"Unknown"} *',
+                                style: MyStyles.font10GreyWeight400Poppins,)),
+                        ),
+                        Padding(
+                          padding: EdgeInsetsDirectional.only(start: 30.w,end: 30.w),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              state.abstract[index].title??"Unknown",
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: MyStyles.font14GreyLightWeight500Poppins,),
+                          ),
+                        ),
+                        Padding(
+                          padding: EdgeInsetsDirectional.only(end: 40.w),
+                          child: Align(
+                              alignment: Alignment.topRight,
+                              child: Text(state.abstract[index].publishedAt??"00:00", style: MyStyles
+                                  .font13GreyLighterWeight400Inter,)),
+                        )
+                      ],
+                    ),
+                separatorBuilder: (BuildContext context, int index) =>
+                    SizedBox(height: 20.h,)
+                ,),
+            ),
+          );
+        }
+        else if(state is NewsListError) {
+          return Center(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Failed to fetch news', style: MyStyles.font22BlackWeight700Poppins),
+                SizedBox(height: 20.h,),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: MyColors.blue,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.w)),
+                    elevation: 1,
                   ),
-                  Padding(
-                    padding:  EdgeInsetsDirectional.only(start: 30.w),
-                    child: Text('Why are football`s biggest clubs starting a new tournament?',maxLines: 2,overflow: TextOverflow.ellipsis,style: MyStyles.font14GreyLightWeight500Poppins,),
-                  ),
-                  Padding(
-                    padding:  EdgeInsetsDirectional.only(end: 40.w),
-                    child: Align(
-                        alignment: Alignment.topRight,
-                        child: Text('3 hours ago',style: MyStyles.font13GreyLighterWeight400Inter,)),
-                  )
-                ],
-              ), separatorBuilder: (BuildContext context, int index) =>SizedBox(height: 20.h,)
-          ,),
-      ),
+                  onPressed: () {
+                    BlocProvider.of<NewsListCubit>(context).fetchNewsList(sourceId: sourceId);
+                  }, child: Text('TryAgain',style: MyStyles.font22WhiteWeight400Exo,),)
+              ],
+            ),
+          );
+        }
+        else {
+          return  Expanded(
+            child: Center(
+              child: CircularProgressIndicator(
+                color: MyColors.green,
+              ),
+            ),
+          );
+        }
+    },
     );
   }
 }

--- a/lib/features/one_category_feature/presentation/widgets/tap_bar_section.dart
+++ b/lib/features/one_category_feature/presentation/widgets/tap_bar_section.dart
@@ -1,25 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:news_app_route1/features/category_features/data/models/nav_model.dart';
+import 'package:news_app_route1/features/one_category_feature/presentation/manager/news_list_cubit.dart';
 import 'package:news_app_route1/features/one_category_feature/presentation/widgets/tap_item.dart';
 
 class TapBarSection extends StatelessWidget {
-   const TapBarSection({
+  const TapBarSection({
     super.key, required this.data,
   });
+
   final NavigationModel data;
 
   @override
   Widget build(BuildContext context) {
-    return  DefaultTabController(length: data.source!.length,
-        child: TabBar(
-            isScrollable: true,
-            dividerColor: Colors.transparent,
-            indicatorColor: Colors.transparent,
-            physics: BouncingScrollPhysics(),
-            tabAlignment: TabAlignment.center,
-            tabs:data.source!.map((e){
-              return TapItem(text: e.name??'');
-            }).toList(),
-        ));
+    return BlocBuilder<NewsListCubit,NewsListState>(
+      builder: (context, state) {
+        return DefaultTabController(length: data.source!.length,
+            child: TabBar(
+              isScrollable: true,
+              onTap: (ind) {
+                 BlocProvider.of<NewsListCubit>(context).selectCategory(ind);
+              },
+              dividerColor: Colors.transparent,
+              indicatorColor: Colors.transparent,
+              physics: const BouncingScrollPhysics(),
+              tabAlignment: TabAlignment.center,
+              tabs: data.source!.map((e) {
+                return TapItem(text: e.name ?? '',
+                  isSelected:BlocProvider.of<NewsListCubit>(context).selected == data.source?.indexOf(e),);
+              }).toList(),
+            ));
+      },
+    );
   }
 }
+

--- a/lib/features/one_category_feature/presentation/widgets/tap_item.dart
+++ b/lib/features/one_category_feature/presentation/widgets/tap_item.dart
@@ -4,20 +4,21 @@ import '../../../../core/themes/my_colors.dart';
 import '../../../../core/themes/my_styles.dart';
 
 class TapItem extends StatelessWidget {
-  const TapItem({super.key, required this.text});
+  const TapItem({super.key, required this.text, required this.isSelected});
   final String text;
+  final bool isSelected;
   @override
   Widget build(BuildContext context) {
     return Container(
       height: 34.h,
       decoration: BoxDecoration(
-          color: Colors.transparent,
+          color:isSelected?MyColors.green: Colors.transparent,
           borderRadius: BorderRadius.circular(25),
           border: Border.all(width: 2,color: MyColors.green,)
       ),
       child: Padding(
         padding:  EdgeInsetsDirectional.symmetric(horizontal: 5.w),
-        child: Center(child: Text(text,maxLines: 1,style: MyStyles.font14GreenWeight400Exo,)),
+        child: Center(child: Text(text,maxLines: 1,style: MyStyles.font14GreenWeight400Exo.copyWith(color: isSelected?MyColors.whiteColor:MyColors.green),)),
       ),
     );
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
+import sqflite
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -57,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -97,6 +129,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -110,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -227,6 +291,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
@@ -243,6 +315,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.10"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -251,6 +371,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   provider:
     dependency: transitive
     description:
@@ -259,6 +395,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -272,6 +416,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "7b41b6c3507854a159e24ae90a8e3e9cc01eb26a477c118d6dca065b5f55453e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4+2"
   stack_trace:
     dependency: transitive
     description:
@@ -296,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: a824e842b8a054f91a728b783c177c1e4731f6b124f9192468457a8913371255
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -320,6 +496,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.2"
   vector_graphics:
     dependency: transitive
     description:
@@ -368,6 +552,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:
@@ -377,5 +569,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.4.4 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   dartz: ^0.10.1
   bloc: ^8.1.4
   flutter_bloc: ^8.1.6
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added `NewsListModel` to represent news data.
- Implemented `GetNewsListRepository` and its implementation for fetching news.
- Created `NewsListCubit` and states for managing news list state.
- Updated `HomeCategoryScreen` to use `NewsListCubit` for displaying news.
- Enhanced `ListViewOfCategoryHomeScreen` to display news using `CachedNetworkImage`.
- Modified `TapBarSection` to handle category selection with BLoC.
- Added `cached_network_image` dependency in `pubspec.yaml`.
- Registered necessary plugins in `GeneratedPluginRegistrant.swift`.